### PR TITLE
Handle repos with hypens in the name

### DIFF
--- a/Buildfile
+++ b/Buildfile
@@ -2,6 +2,7 @@
 
 # Get the current directory name
 MODULE_REPO_NAME="${PWD##*/}"
+MODULE_KEY="$(echo $MODULE_REPO_NAME | sed 's/-/_/g')"
 
 # Clone Ash
 cd ..
@@ -11,7 +12,7 @@ git clone --recursive https://github.com/ash-shell/ash.git
 mkdir -p ash/global_modules/github.com/ash-shell/
 mv "$MODULE_REPO_NAME" "ash/global_modules/github.com/ash-shell/$MODULE_REPO_NAME"
 touch ash/global_modules/module_aliases.yaml
-printf "$MODULE_REPO_NAME: github.com/ash-shell/$MODULE_REPO_NAME" >> ash/global_modules/module_aliases.yaml
+printf "$MODULE_KEY: github.com/ash-shell/$MODULE_REPO_NAME" >> ash/global_modules/module_aliases.yaml
 
 # Move to ash's repo and output that directory
 # we're going to want to switch to that directory

--- a/travis.yml
+++ b/travis.yml
@@ -4,7 +4,7 @@ os:
 language: bash
 
 before_script:
-    - module=${PWD##*/}
+    - module="$(echo ${PWD##*/} | sed 's/-/_/g')"
     - out=$(curl -A "" -L "http://bit.ly/1RSkntI" | sh); cd $(tail -n1 <<< "${out}")
 
 script:


### PR DESCRIPTION
YAML doesn't support hyphens in the names of keys, so this was actually
throwing off our yaml parser when a repo had a hyphen in it.

Fixes #1
